### PR TITLE
Make scroll-iv work for all elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 var animate = require('amator');
+var scrollParent = require('scrollparent');
 
 module.exports = scrollIntoView;
 
 function scrollIntoView(el, options) {
   if (!el) throw new Error('Element is required in scrollIntoView')
 
-  var parent = el.parentNode
+  var parent = scrollParent(el);
   if (!parent) throw new Error('Element is not attached to the DOM in scrollIntoView')
 
   var parentTop = parent.getBoundingClientRect().top

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scroll-iv",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Smooth cross browser scrollIntoView",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "url": "https://github.com/anvaka/scroll-iv"
   },
   "dependencies": {
-    "amator": "^1.0.0"
+    "amator": "^1.0.0",
+    "scrollparent": "^1.0.0"
   }
 }


### PR DESCRIPTION
The old implementation only worked for elements which had a parent element that was scrollable. However that's not always the case and its why the library didn't work for me.

It turned out to be a very easy fix though since there was a npm package that detects the scrollable parent.
